### PR TITLE
Version 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 1.1.0
+
+- New: If upc is empty and ean not empty, ean code is synced in Reverb API in the upc field
+- Fix: Add a new environment variable PS_ERASE_DB=1 in the env_file for the Docker image of PrestaShop
+- Fix: Update new version of PrestaShop images in the Dockerfile (PrestaShop 1.6.1.16 and 1.7.2.0)
+
 # Version 1.0.5
 
 - Fix a bug to the bulk sync button (sync status)

--- a/conf/docker/Dockerfile16
+++ b/conf/docker/Dockerfile16
@@ -1,4 +1,4 @@
-FROM prestashop/prestashop:1.6.1.15
+FROM prestashop/prestashop:1.6.1.16
 
 MAINTAINER Johan PROTIN <jprotin@boutiquedubio.fr>
 

--- a/conf/docker/Dockerfile17
+++ b/conf/docker/Dockerfile17
@@ -1,4 +1,4 @@
-FROM prestashop/prestashop:1.7.1.0
+FROM prestashop/prestashop:1.7.2.0
 
 MAINTAINER Johan PROTIN <jprotin@boutiquedubio.fr>
 

--- a/conf/env/MYSQL.env
+++ b/conf/env/MYSQL.env
@@ -1,7 +1,7 @@
 ####################################
 ###           ENV MYSQL
 ####################################
-MYSQL_HOST=mysql
+MYSQL_HOST=mysql-reverb
 MYSQL_ROOT_PASSWORD=admin
 MYSQL_USER=root
 MYSQL_PASSWORD=admin

--- a/conf/env/PRESTASHOP-16.env
+++ b/conf/env/PRESTASHOP-16.env
@@ -3,4 +3,4 @@
 ####################################
 PS_DOMAIN=localhost:8016
 DB_NAME=prestashop16
-DB_SERVER=mysql
+DB_SERVER=mysql-reverb

--- a/conf/env/PRESTASHOP-17.env
+++ b/conf/env/PRESTASHOP-17.env
@@ -3,4 +3,4 @@
 ####################################
 PS_DOMAIN=localhost:8017
 DB_NAME=prestashop17
-DB_SERVER=mysql
+DB_SERVER=mysql-reverb

--- a/conf/env/PRESTASHOP.env
+++ b/conf/env/PRESTASHOP.env
@@ -16,7 +16,7 @@ PS_FOLDER_INSTALL=installOLD
 ADMIN_MAIL=demo@reverb.com
 ADMIN_PASSWD=123456
 PS_HANDLE_DYNAMIC_DOMAIN=0
-PS_ERASE_DB=1
+PS_ERASE_DB=0
 
 ####################################
 ###    X DEBUG

--- a/conf/env/PRESTASHOP.env
+++ b/conf/env/PRESTASHOP.env
@@ -16,6 +16,7 @@ PS_FOLDER_INSTALL=installOLD
 ADMIN_MAIL=demo@reverb.com
 ADMIN_PASSWD=123456
 PS_HANDLE_DYNAMIC_DOMAIN=0
+PS_ERASE_DB=1
 
 ####################################
 ###    X DEBUG

--- a/docker-compose.ps16.yml
+++ b/docker-compose.ps16.yml
@@ -6,7 +6,7 @@ web16:
     - "8016:80"
   links:
     - smtp
-    - mysql
+    - mysql-reverb
   env_file:
     - ./conf/env/PRESTASHOP.env
     - ./conf/env/PRESTASHOP-16.env

--- a/docker-compose.ps17.yml
+++ b/docker-compose.ps17.yml
@@ -6,7 +6,7 @@ web17:
     - "8017:80"
   links:
     - smtp
-    - mysql
+    - mysql-reverb
   env_file:
     - ./conf/env/PRESTASHOP.env
     - ./conf/env/PRESTASHOP-17.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-mysql:
+mysql-reverb:
   container_name: reverb_mysql
   image: mysql:5.6.23
   env_file:
@@ -11,4 +11,4 @@ smtp:
   image: schickling/mailcatcher
   container_name: smtp-reverb
   ports:
-    - "1082:1080"
+    - "1090:1080"

--- a/src/reverb/classes/mapper/ProductMapper.php
+++ b/src/reverb/classes/mapper/ProductMapper.php
@@ -91,7 +91,7 @@ class ProductMapper
         $product->has_inventory = $product_ps['quantity_stock'] > 0 ? 1 : false;
         $product->inventory = $product_ps['quantity_stock'];
         $product->sku = $product_ps['reference'];
-        $product->upc = $product_ps['upc'];
+        $product->upc = !empty($product_ps['upc']) ? $product_ps['upc'] : $product_ps['ean13'] ;
         $product->publish = false;
         $product->title = $product_ps['name'];
         $product->categories = $this->mapCategories($product_ps);

--- a/src/reverb/classes/mapper/models/ProductReverb.php
+++ b/src/reverb/classes/mapper/models/ProductReverb.php
@@ -43,6 +43,8 @@ class ProductReverb
 
     public $upc;
 
+    public $ean13;
+
     public $offers_enabled;
 
     public $shipping_profile_id;

--- a/src/reverb/classes/models/ReverbSync.php
+++ b/src/reverb/classes/models/ReverbSync.php
@@ -46,7 +46,7 @@ class ReverbSync
             ->leftJoin('attribute_group_lang', 'agl', 'agl.`id_attribute_group` = ag.`id_attribute_group` AND agl.`id_lang` = ' . $this->module->language_id)
             ->where('ra.`reverb_enabled` = 1')
             ->where('pl.`id_lang` = ' . (int)$this->module->language_id)
-            ->groupBy('p.id_product, p.reference, rs.status, rs.reverb_id, rs.details, rs.reverb_slug, rs.date, pa.id_product_attribute, pa.upc');
+            ->groupBy('p.id_product, p.reference, rs.status, rs.reverb_id, rs.details, rs.reverb_slug, rs.date, pa.id_product_attribute, pa.upc, pa.ean13');
 
         //=========================================
         //          WHERE CLAUSE
@@ -97,6 +97,7 @@ class ReverbSync
             'p.id_product as id_product,' .
             'IF (pa.id_product_attribute IS NULL, p.reference, pa.reference) as reference,' .
             'IF (pa.upc IS NULL, p.upc, pa.upc) as upc,' .
+            'IF (pa.ean13 IS NULL, p.ean13, pa.ean13) as ean13,' .
             'IF (pa.id_product_attribute IS NULL, pl.name, CONCAT(pl.name, \' \', GROUP_CONCAT(CONCAT (agl.name, \' \', al.name) SEPARATOR \', \'))) as name,' .
             'rs.status as status,' .
             'rs.reverb_id as reverb_id,' .
@@ -419,6 +420,7 @@ class ReverbSync
             'pa.id_product_attribute, agl.name as attribute_group_name, al.name as attribute_name, ' .
             'IF (pa.id_product_attribute IS NULL, p.reference, pa.reference) as reference,' .
             'IF (pa.upc IS NULL, p.upc, pa.upc) as upc,' .
+            'IF (pa.ean13 IS NULL, p.ean13, pa.ean13) as ean13,' .
             'IF (pa.id_product_attribute IS NULL, pl.name, CONCAT(pl.name, \' \', GROUP_CONCAT(CONCAT (agl.name, \' \', al.name) SEPARATOR \', \'))) as name'
         );
 
@@ -503,6 +505,7 @@ class ReverbSync
             'pa.id_product_attribute, agl.name as attribute_group_name, al.name as attribute_name, ' .
             'IF (pa.id_product_attribute IS NULL, p.reference, pa.reference) as reference,' .
             'IF (pa.upc IS NULL, p.upc, pa.upc) as upc,' .
+            'IF (pa.ean13 IS NULL, p.ean13, pa.ean13) as ean13,' .
             'IF (pa.id_product_attribute IS NULL, pl.name, CONCAT(pl.name, \' \', GROUP_CONCAT(CONCAT (agl.name, \' \', al.name) SEPARATOR \', \'))) as name'
         );
 

--- a/src/reverb/config.xml
+++ b/src/reverb/config.xml
@@ -2,7 +2,7 @@
 <module>
 	<name>reverb</name>
 	<displayName><![CDATA[ Reverb]]></displayName>
-	<version><![CDATA[1.0.5]]></version>
+	<version><![CDATA[1.1.0]]></version>
 	<description><![CDATA[Reverb is the best place anywhere to sell your guitar, amp, drums, bass, or other music gear.Built for and by musicians, our marketplace offers a broad variety of tools to help buy and sell, and has the lowest transaction fees of any online marketplace.]]></description>
 	<author><![CDATA[Johan PROTIN]]></author>
 	<tab><![CDATA[market_place]]></tab>

--- a/src/reverb/doc/documentation-reverb-en.md
+++ b/src/reverb/doc/documentation-reverb-en.md
@@ -49,6 +49,10 @@ For PrestaShop 1.7, you need to edit the file /conf/env/PRESTASHOP-17.env
     DB_NAME=prestashop16
     DB_SERVER=mysql'
 
+Caution: If you are launching the Reverb project with Docker for the first time, consider changing the environment variable PS_ERASE_DB = 0 to 1.
+To change this variable, go to conf > env > PRESTASHOP.env
+PS_ERASE_DB: Only with PS_INSTALL_AUTO=1. Drop and create the mysql database. All previous mysql data will be lost (default value: 0).
+
 You can change the PS_DOMAIN variable with the domain name you want, we recommend in the local environment to stay on the localhost domain.
 
 

--- a/src/reverb/doc/documentation-reverb-fr.md
+++ b/src/reverb/doc/documentation-reverb-fr.md
@@ -49,6 +49,11 @@ Pour PrestaShop 1.7, il faut éditer le fichier /conf/env/PRESTASHOP-17.env
     DB_NAME=prestashop16
     DB_SERVER=mysql'
 
+Attention:
+Si vous lancez le projet Reverb avec Docker pour la première fois, pensez à modifier la variable d'environnement PS_ERASE_DB=0 à 1.
+To change this variable, go to conf > env > PRESTASHOP.env
+PS_ERASE_DB: Seulement avec PS_INSTALL_AUTO = 1. Déposez et créez la base de données mysql. Toutes les données mysql précédentes seront perdues (valeur par défaut: 0).
+
 Vous pouvez modifier la variable PS_DOMAIN avec le nom de domaine que vous souhaitez, nous recommandons en local de rester sur le domaine localhost.
 
 

--- a/src/reverb/reverb.php
+++ b/src/reverb/reverb.php
@@ -58,7 +58,7 @@ class Reverb extends Module
     {
         $this->name = 'reverb';
         $this->tab = 'market_place';
-        $this->version = '1.0.5';
+        $this->version = '1.1.0';
         $this->author = 'Johan PROTIN';
         $this->need_instance = 0;
 


### PR DESCRIPTION
New: If upc is empty and ean not empty, ean code is synced in Reverb API in the upc field
Fix: Add a new environment variable PS_ERASE_DB=1 in the env_file for the Docker image of PrestaShop
Fix: Update new version of PrestaShop images in the Dockerfile (PrestaShop 1.6.1.16 and 1.7.2.0)