### PR TITLE
Feature/bug url images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 1.4.5
+
+- Fix: replace image type "large_default" by "large" when the listing sync is n progress
+
 # Version 1.4.4
 
 - Fix: no duplication of order when the status is on Error

--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ Read the **[project documentation][doc-home-en] in English** for comprehensive i
 The **Reverb.com** is available under the **Apache 2.0 License**. Check out the [license file][project-license] for more information.
 
 
-[doc-home-fr]: https://github.com/jprotin/reverb-prestashop/blob/develop/src/reverb/doc/documentation-reverb-fr.md
-[doc-home-en]: https://github.com/jprotin/reverb-prestashop/blob/develop/src/reverb/doc/documentation-reverb-fr.md
+[doc-home-fr]: https://github.com/reverbdotcom/prestashop/blob/master/src/reverb/doc/documentation-reverb-fr.md
+[doc-home-en]: https://github.com/reverbdotcom/prestashop/blob/master/src/reverb/doc/documentation-reverb-en.md
 [reverb-help]: https://reverb.com/fr/page/contact
-[project-issues]: https://github.com/jprotin/reverb-prestashop
+[project-issues]: https://github.com/reverbdotcom/prestashop/
 [project-license]: LICENSE.md
 [project-changelog]: CHANGELOG.md
 [project-contributing]: CONTRIBUTING.md

--- a/src/reverb/classes/mapper/ProductMapper.php
+++ b/src/reverb/classes/mapper/ProductMapper.php
@@ -245,7 +245,7 @@ class ProductMapper
     private function getImagesUrl($product)
     {
         $urls = array();
-        $type_img = "large_default";
+        $type_img = "large";
         if (version_compare(_PS_VERSION_, '1.7', '<')) {
             $type_img = "thickbox";
         }

--- a/src/reverb/reverb.php
+++ b/src/reverb/reverb.php
@@ -59,7 +59,7 @@ class Reverb extends Module
     {
         $this->name = 'reverb';
         $this->tab = 'market_place';
-        $this->version = '1.4.4';
+        $this->version = '1.4.5';
         $this->author = 'Johan PROTIN';
         $this->need_instance = 0;
 


### PR DESCRIPTION
Fix: replace image type "large_default" by "large" when the listing sync is in progress