### PR TITLE
For release Version 1.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 1.4.7
+
+- Fix: If stock = 0 and Publish = true in the listing sync, the sync force publish = false.
+
 # Version 1.4.6
 
 - Fix: Integration Reverb orders with status shipped in Prestashop when Prestashop orders don't exist

--- a/src/reverb/classes/mapper/ProductMapper.php
+++ b/src/reverb/classes/mapper/ProductMapper.php
@@ -138,7 +138,7 @@ class ProductMapper
         }
 
         if ($this->module->getReverbConfig(\Reverb::KEY_SETTINGS_AUTO_PUBLISH)) {
-            $product->publish = 1;
+            $product->publish = $product_ps['quantity_stock'] > 0 ? 1 : false;
         }
 
         return $product;

--- a/src/reverb/reverb.php
+++ b/src/reverb/reverb.php
@@ -59,7 +59,7 @@ class Reverb extends Module
     {
         $this->name = 'reverb';
         $this->tab = 'market_place';
-        $this->version = '1.4.6';
+        $this->version = '1.4.7';
         $this->author = 'Johan PROTIN';
         $this->need_instance = 0;
 


### PR DESCRIPTION
Fix the stock = 0 and publish = true when the listing sync is executed.