### PR TITLE
Version 1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 1.5.2
+
+- Fix: If the Model field is empty then it is replaced by the sku automatically (available on PrestaShop product management and Reverb Bulk Edit)
+
 # Version 1.5.1
 
 - Fix: retro-compatibility Tools::getAllValues() < PS 1.6.1.0

--- a/conf/docker/Dockerfile17
+++ b/conf/docker/Dockerfile17
@@ -1,12 +1,13 @@
-FROM prestashop/prestashop:1.7-7.1-apache
+FROM prestashop/prestashop:1.7-7.2-apache
 
 MAINTAINER Johan PROTIN <jprotin@boutiquedubio.fr>
 
 RUN apt-get update \
+        && apt-get install -y curl gnupg \
+        && curl -sL https://deb.nodesource.com/setup_10.x | bash - \
         && apt-get install -y ssmtp vim git cron \
-        && apt-get install -y nodejs npm \
+        && apt-get install -y nodejs \
         && npm install -g bower \
-                && ln -s /usr/bin/nodejs /usr/bin/node \
                 && echo '{ "allow_root": true }' > /root/.bowerrc \
                 && curl -sS https://getcomposer.org/installer | php -- --filename=composer -- --install-dir=/usr/local/bin \
                 && echo "sendmail_path = /usr/sbin/ssmtp -t" > /usr/local/etc/php/conf.d/sendmail.ini \

--- a/src/reverb/classes/mapper/ProductMapper.php
+++ b/src/reverb/classes/mapper/ProductMapper.php
@@ -91,6 +91,8 @@ class ProductMapper
         }
         if(!empty($product_ps['model'])){
             $product->model = $product_ps['model'];
+        } else {
+            $product->model = $product_ps['reference'];
         }
         $product->has_inventory = $product_ps['quantity_stock'] > 0 ? 1 : false;
         $product->inventory = $product_ps['quantity_stock'];

--- a/src/reverb/controllers/admin/AdminReverbConfigurationController.php
+++ b/src/reverb/controllers/admin/AdminReverbConfigurationController.php
@@ -369,6 +369,14 @@ class AdminReverbConfigurationController extends ModuleAdminController
         $db = Db::getInstance();
 
         foreach ($productIds as $productId) {
+
+            // check if the model is empty
+            if (empty(Tools::getValue('reverb_model'))) {
+                $productObj = new Product($productId, false, $this->module->language_id);
+                $attributes['model'] =  $productObj->reference;
+                unset($productObj);
+            }
+
             // Get reverb attributes
             $attribute = $this->module->getAttribute($productId, TRUE);
 

--- a/src/reverb/reverb.php
+++ b/src/reverb/reverb.php
@@ -59,7 +59,7 @@ class Reverb extends Module
     {
         $this->name = 'reverb';
         $this->tab = 'market_place';
-        $this->version = '1.5.1';
+        $this->version = '1.5.2';
         $this->author = 'Johan PROTIN';
         $this->need_instance = 0;
 
@@ -1146,9 +1146,10 @@ class Reverb extends Module
     public function hookActionProductSave()
     {
         $id_product = Tools::getValue('id_product');
+        $sku = Tools::getValue('reference');
 
         if (isset($id_product) && $id_product) {
-            $model = Tools::getValue('reverb_model');
+            $model = (empty(Tools::getValue('reverb_model')) ? $sku : Tools::getValue('reverb_model'));
             $settingsReverb = Tools::getValue('reverb_enabled');
             $condition = Tools::getValue('reverb_condition');
             $finish = Tools::getValue('reverb_finish');


### PR DESCRIPTION
Fix: If the Model field is empty then it is replaced by the sku automatically (available on PrestaShop product management and Reverb Bulk Edit)